### PR TITLE
Improve refined and enum types

### DIFF
--- a/.changeset/gentle-months-camp.md
+++ b/.changeset/gentle-months-camp.md
@@ -1,0 +1,10 @@
+---
+"@carbonteq/hexapp": patch
+---
+
+Improve refined amd enum types
+
+- Add `$infer` and `$inferInner` for simpler type extraction
+- Add `value` method for getting the unbranded type easily
+- Add `matchEnum` for pattern matching enum type (with exhaustive checking and type safety)
+- Add `eq` 'static' method in enum types for simpler equality checks

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.3",
 		"@changesets/cli": "^2.27.7",
-		"@swc-node/core": "^1.13.2",
-		"@swc-node/register": "^1.10.3",
+		"@swc-node/core": "^1.13.3",
+		"@swc-node/register": "^1.10.9",
 		"@swc/core": "^1.6.13",
 		"@swc/jest": "^0.2.36",
 		"@swc/types": "^0.1.9",
@@ -58,7 +58,7 @@
 		"changesets": "^1.0.2",
 		"jest": "^29.7.0",
 		"jest-extended": "^4.0.2",
-		"jsr": "^0.13.0",
+		"jsr": "^0.13.1",
 		"rimraf": "^5.0.7",
 		"rollup": "^4.18.1",
 		"rollup-plugin-node-externals": "^7.1.2",
@@ -67,7 +67,7 @@
 		"typescript": "5.5.3"
 	},
 	"dependencies": {
-		"@carbonteq/fp": "^0.5.0",
+		"@carbonteq/fp": "^0.5.3",
 		"zod": "^3.23.8",
 		"zod-validation-error": "^3.3.0"
 	},

--- a/src/domain/base.entity.ts
+++ b/src/domain/base.entity.ts
@@ -71,3 +71,8 @@ export abstract class BaseEntity implements IEntity {
 	//@ts-ignore
 	abstract serialize();
 }
+
+export type SimpleSerialized<
+	EntityInterface extends IEntity,
+	T extends keyof EntityInterface = keyof IEntity,
+> = SerializedEntity & Omit<EntityInterface, T | keyof IEntity>;

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -3,6 +3,7 @@ export type {
 	IEntity,
 	IEntityForUpdate,
 	SerializedEntity,
+	SimpleSerialized,
 } from "./base.entity";
 export {
 	InvalidEmail,
@@ -12,6 +13,7 @@ export {
 	DateTime,
 	createRefinedType,
 	createEnumType,
+	matchEnum,
 	EnumValidationError,
 	InvalidUUID,
 	type Unbrand,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,4 +1,9 @@
-export { assertUnreachable, assertUnreachablePassthrough } from "./type.utils";
+export {
+	unsafeCast,
+	assertUnreachable,
+	assertUnreachablePassthrough,
+	isPromise,
+} from "./type.utils";
 export type {
 	ArrType,
 	Constructable,
@@ -9,6 +14,7 @@ export type {
 	IterType,
 	Omitt,
 	PartialBy,
+	UnsafeCast,
 } from "./type.utils";
 export {
 	sortByCreatedAt,
@@ -27,7 +33,6 @@ export {
 	randomChoice,
 	shuffle,
 	shuffleInplace,
-	isPromise,
 } from "./misc.utils";
 export { ZodUtils, handleZodErr } from "./zod.utils";
 export { ZodSchemas } from "./zod.schemas";

--- a/src/shared/misc.utils.ts
+++ b/src/shared/misc.utils.ts
@@ -74,16 +74,12 @@ export const extend = <T, U extends Record<string, unknown>>(
 	original: T,
 	extensions: U,
 ): T & U => {
-	const res = original as T & U;
+	//@ts-expect-error
+	return Object.assign(original, extensions);
 
-	//@ts-ignore
-	for (const [k, v] of Object.entries(extensions)) res[k] = v;
-
-	return res;
+	// const res = original as T & U;
+	// //@ts-ignore
+	// for (const [k, v] of Object.entries(extensions)) res[k] = v;
+	//
+	// return res;
 };
-
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-export const isPromise = <T>(obj: any): obj is Promise<T> =>
-	!!obj &&
-	(typeof obj === "object" || typeof obj === "function") &&
-	typeof obj.then === "function";

--- a/src/shared/type.utils.ts
+++ b/src/shared/type.utils.ts
@@ -1,6 +1,9 @@
 import type { AppResult } from "..//app/result";
 
-export type EmptyObject = Record<string, never>;
+export type EmptyObject = Record<string | number | symbol, never>;
+
+export type UnsafeCast<T, U> = T extends U ? T : U;
+export const unsafeCast = <U, T = unknown>(val: T): U => val as unknown as U;
 
 type JsonValue =
 	| string
@@ -76,3 +79,9 @@ export const assertUnreachable = (x: never): never => {
  * @param x {never} - This is a type that should never be used. It is used to ensure that the switch statement is exhaustive.
  */
 export const assertUnreachablePassthrough = (x: never): never => x;
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export const isPromise = <T>(obj: any): obj is Promise<T> =>
+	!!obj &&
+	(typeof obj === "object" || typeof obj === "function") &&
+	typeof obj.then === "function";

--- a/tests/app/result/app-result.spec.ts
+++ b/tests/app/result/app-result.spec.ts
@@ -58,6 +58,7 @@ describe("alternative constructors", () => {
 
 		it("from err result with msg", () => {
 			const msg = "some message";
+			//@ts-expect-error
 			const err = new InvalidOpErr(msg);
 			const result = AppResult.fromResult(Result.Err(err));
 
@@ -65,7 +66,7 @@ describe("alternative constructors", () => {
 			const unwrappedErr = result.unwrapErr();
 
 			expect(unwrappedErr.status).toBe(AppErrStatus.InvalidOperation);
-			expect(unwrappedErr.message).toBe(`<InvalidOperation>: "${msg}"`);
+			expect(unwrappedErr.message).toBe(msg);
 		});
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -556,10 +556,10 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.3.tgz#6a9dc5a4e13357277da43c015cd5cdc374035448"
   integrity sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==
 
-"@carbonteq/fp@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@carbonteq/fp/-/fp-0.5.0.tgz#ef8138c383b04061cd84a4faaf33717e107ebe24"
-  integrity sha512-zY0S0+qseNiKxsecFHNZYZwRsEirVpwDLdVDIqVLsBhEzn1Arao+q7r2cQ18jseddokph68xGbydiz6SOX1zKw==
+"@carbonteq/fp@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@carbonteq/fp/-/fp-0.5.3.tgz#85a1f7c8a21de5a554b4cc84f26323bc6504cf41"
+  integrity sha512-ceKxS2LP/zUYhhMlUTC3qRPfb4UvCmfaUNk2WWH2uAsfFOHYSt3nfh6fl+t8M7bBGklFVvBmLMQZ/WGjV72FJA==
 
 "@changesets/apply-release-plan@^7.0.4":
   version "7.0.4"
@@ -1175,57 +1175,62 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oxc-resolver/binding-darwin-arm64@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-1.10.0.tgz#c98eee3fba9af05c98a885f7c116d276ca1137f1"
-  integrity sha512-sJpH25yjQQf+59g4WAhrZYSiLiev2kFmHIvANeX8/ZAUEvtmRKmw/sCfK1cS6F6iRWNlSSjKbmahaY0ubS95ug==
+"@oxc-resolver/binding-darwin-arm64@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-1.10.2.tgz#7fd04e5f07bd4dfc9abe9416afe107b925df1f98"
+  integrity sha512-aOCZYXqmFL+2sXlaVkYbAOtICGGeTFtmdul8OimQfOXHJods6YHJ2nR6+rEeBcJzaXyXPP18ne1IsEc4AYL1IA==
 
-"@oxc-resolver/binding-darwin-x64@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-1.10.0.tgz#938dbe89665b536f3eb1cf01b31e6fcabb9d4f64"
-  integrity sha512-ETtWuoq5nmg1810bMeKCQ5vKq85Sy+arx7LDVEUFvkz4g0+6WP1SVYr4st7jBh8k6AhXAw1d7H5zRTL6Sfep/w==
+"@oxc-resolver/binding-darwin-x64@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-1.10.2.tgz#b73dfa73c7af1ee808a52f6873274b47af284716"
+  integrity sha512-6WD7lHGkoduFZfUgnC2suKOlqttQRKxWsiVXiiGPu3mfXvQAhMd/gekuH1t8vOhFlPJduaww15n5UB0bSjCK+w==
 
-"@oxc-resolver/binding-linux-arm-gnueabihf@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.10.0.tgz#9c445d03d8faba1e6953af4367ecddfb2e7c7bab"
-  integrity sha512-0h8Tn0c2aUagCO0nNU0YwSqBbNBKrc4/0uSwM/gAKrzmjEbup2dZEDkvAoBzEFgGc8DFdvKv/uxydgJvpyAGZQ==
+"@oxc-resolver/binding-freebsd-x64@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-1.10.2.tgz#b1303a29ff8eafc267683d253b7458b78f68245b"
+  integrity sha512-nEqHWx/Ot5p7Mafj8qH6vFlLSvHjECxAcZwhnAMqRuQu1NgXC/QM3emkdhVGy7QJgsxZbHpPaF6TERNf5/NL9Q==
 
-"@oxc-resolver/binding-linux-arm64-gnu@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.10.0.tgz#1e7138abefad9196ff57969c31df761070a4728f"
-  integrity sha512-RtJAj35/v4mm4MIEwlz8nomcgEpktdgOoIRdVaneSDjfTSQdagC34Bx9TRGLKt5u3xgP4xYx0rFTSBCmJUJoSQ==
+"@oxc-resolver/binding-linux-arm-gnueabihf@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.10.2.tgz#f921703edfc1e972408394b9c639c50e984ff16e"
+  integrity sha512-+AlZI0fPnpfArh8aC5k2295lmQrxa2p8gBLxC3buvCkz0ZpbVLxyyAXz3J2jGwJnmc5MUPLEqPYw6ZlAGH4XHA==
 
-"@oxc-resolver/binding-linux-arm64-musl@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.10.0.tgz#bbfa9974d12b023621cb2340542d0080f43bfa5a"
-  integrity sha512-d9PBWbK3SCrj/018LoCyQ34LEEKZXyVwA/UCtRzCvZmgRxlRDmrim/xgl2IyXEqu3/9eeGnGnip1ceATGnAacA==
+"@oxc-resolver/binding-linux-arm64-gnu@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.10.2.tgz#173982495965af46d028329ce1e99d7dd584e483"
+  integrity sha512-8fZ8NszFaUZaoA8eUwkF2lHjgUs76aFiewWgG/cjcZmwKp+ErZQLW8eOvIWZ4SohHQ+ScvhVsSaU2PU38c88gw==
 
-"@oxc-resolver/binding-linux-x64-gnu@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.10.0.tgz#e23f65cb567f40ec37f1ecbe252fcf5826b5817b"
-  integrity sha512-dv2YPpCk2SQNQI/NiPSr207bdsIBD/1Gn7zpz/r9o6cl0RucHRk4KsMRamkJvWR+jIw0CwGTsgQZZTImcObLCQ==
+"@oxc-resolver/binding-linux-arm64-musl@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.10.2.tgz#323fc30fc4611a2bd0d1a2d73fdea5d91a9c0ae7"
+  integrity sha512-oPrLICrw96Ym9n04FWXWGkbkpF6qJtZ57JSnqI3oQ24xHTt4iWyjHKHQO46NbJAK9sFb3Qce4BzV8faDI5Rifg==
 
-"@oxc-resolver/binding-linux-x64-musl@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-1.10.0.tgz#96c65cef943f31c99a1fc4c2c385b24d28f35e0f"
-  integrity sha512-RdIxtyhPfxd8uUX2IkotnLHAkdrvVvEhv0ZNB31K6CtwVekZKWxSETzodN8+2LLNgp+4CClMHxhc59IapGUPKA==
+"@oxc-resolver/binding-linux-x64-gnu@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.10.2.tgz#f7f8bd53f146a28176180a1fa8b47885427df7e9"
+  integrity sha512-eli74jTAUiIfqi8IPFqiPxQS69Alcr6w/IFRyf3XxrkxeFGgcgxJkRIxWNTKJ6T3EXxjuma+49LdZn6l9rEj7A==
 
-"@oxc-resolver/binding-wasm32-wasi@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-1.10.0.tgz#c43bc5c228edcd845c33f84ee23b58f6e43e026f"
-  integrity sha512-drqVsc2dj7rUdZ/UBzDxfyuPL8ZBjKYKiuW7RBrYKSOYKA4qNDIqB2qDUTv940WDF4WhrHFpHEjT6Y1Sp+Fvxw==
+"@oxc-resolver/binding-linux-x64-musl@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-1.10.2.tgz#00d3465bc6a2abd9a34d09dc5eeba0479f33059b"
+  integrity sha512-HH9zmjNSQo3rkbqJH5nIjGrtjC+QPrUy0KGGMR/oRCSLuD0cNFJ/Uly1XAugwSm4oEw0+rv6PmeclXmVTKsxhw==
+
+"@oxc-resolver/binding-wasm32-wasi@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-1.10.2.tgz#ed3c49f4887a765503f589bb8b95e9c8d5369adb"
+  integrity sha512-3ItX23q33sfVBtMMdMhVDSe0NX5zBHxHfmFiXhSJuwNaVIwGpLFU7WU2nmq9oNdnmTOvjL8vlhOqiGvumBLlRA==
   dependencies:
     "@napi-rs/wasm-runtime" "^0.2.4"
 
-"@oxc-resolver/binding-win32-arm64-msvc@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.10.0.tgz#8d66576a55590240622d9ed876aedd1b8575d77b"
-  integrity sha512-RbDplFsBJkj4huit8d7XG2wKQ7IMdQhLAUBeK02JzsDDrpNsgD1fa3YOy2oGO3GPUWEJXyhq1okFyyVIHrUf3g==
+"@oxc-resolver/binding-win32-arm64-msvc@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.10.2.tgz#bea966a1ab09d1a8b2823abf488ba1e213a619b7"
+  integrity sha512-aVoj2V+jmQ1N+lVy9AhaLmzssJM0lcKt8D0UL83aNLZJ5lSN7hgBuUXTVmL+VF268f167khjo38z+fbELDVm8Q==
 
-"@oxc-resolver/binding-win32-x64-msvc@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.10.0.tgz#9000c9c197d0e86bcc3ec58378c6a46388cf180c"
-  integrity sha512-0atlXXYIzdzvXBlPwdFde3PppPyapb+KofI9jjM88na9ytsC7Unn9hlV7egr2JSaGKCiEBDK8zOxoG1ueEauVA==
+"@oxc-resolver/binding-win32-x64-msvc@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.10.2.tgz#b43deb60fac0b13add5a259fac3c8fdfffd7333c"
+  integrity sha512-l8BDQWyP0Piw8hlmYPUqTRKLsq+ceG9h+9p6ZrjNzwW9AmJX7T7T2hgoVVHqS6f4WNA/CFkb3RyZP9QTzNkyyA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1345,21 +1350,21 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@swc-node/core@^1.13.2":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@swc-node/core/-/core-1.13.2.tgz#0b3b563edd2a8c951dbaeecfa1795b8cd1b29a30"
-  integrity sha512-skceAbeKUmEK8z1nxStJTTsbIInKqW4n4+ZCYFexy6UsHjsc7MAfR2v5QqNJr/Fl/j+yLY6UkXY2VUU63nEC/Q==
+"@swc-node/core@^1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@swc-node/core/-/core-1.13.3.tgz#0821d01263f48314392d38d80ef1a03fef5f11b3"
+  integrity sha512-OGsvXIid2Go21kiNqeTIn79jcaX4l0G93X2rAnas4LFoDyA9wAwVK7xZdm+QsKoMn5Mus2yFLCc4OtX2dD/PWA==
 
-"@swc-node/register@^1.10.3":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@swc-node/register/-/register-1.10.3.tgz#7f426fbbc069edd73b7231edb2a1199601fa2639"
-  integrity sha512-QSffEXDGh/A6q0SWGEmnvKOqrCY0EiOLhAaS9KGxe2+0RKSOIjuBjTDilBLKHltudNCDkEE6kBljwGz7xoAREA==
+"@swc-node/register@^1.10.9":
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/@swc-node/register/-/register-1.10.9.tgz#9e2660f99a12969d3e5a34144e6a5812c7187680"
+  integrity sha512-iXy2sjP0phPEpK2yivjRC3PAgoLaT4sjSk0LDWCTdcTBJmR4waEog0E6eJbvoOkLkOtWw37SB8vCkl/bbh4+8A==
   dependencies:
-    "@swc-node/core" "^1.13.2"
+    "@swc-node/core" "^1.13.3"
     "@swc-node/sourcemap-support" "^0.5.1"
     colorette "^2.0.20"
     debug "^4.3.5"
-    oxc-resolver "^1.9.2"
+    oxc-resolver "^1.10.2"
     pirates "^4.0.6"
     tslib "^2.6.3"
 
@@ -2962,10 +2967,10 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsr@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/jsr/-/jsr-0.13.0.tgz#58ba62074f2a016a1e54ce7954869b4329bfa29a"
-  integrity sha512-1Ndg3dpv+zXhg+yVd0n6QtAGsA4A8jkYl1/Do3w53+7mJg361n/ge7GpkNmT/zPxmQtUIxLIKdmHn0CfAkn+Hw==
+jsr@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/jsr/-/jsr-0.13.1.tgz#68808335acb2ac8a775f4d416c6af57a1f557ca4"
+  integrity sha512-vKS4Z23V9Ue4hbup85d4dPGi8rNjojoLpZXQDgOudZjJZBvGy03bIzrJEzfMZDiwNx5ARSdp6Y5ua1winxEvsw==
   dependencies:
     kolorist "^1.8.0"
     node-stream-zip "^1.15.0"
@@ -3174,21 +3179,22 @@ outdent@^0.5.0:
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
   integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
 
-oxc-resolver@^1.9.2:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/oxc-resolver/-/oxc-resolver-1.10.0.tgz#5a6d25bfec2ca8f7c504eae2bde699e7fcfa75a5"
-  integrity sha512-FkObNl6JVrbqvvRqXCQhYZvrJHqEJNAjWDuPxHx9CblwoYzL5zcM74Ba30ek3YUopaUSNit3ceaILqShAx+hgw==
+oxc-resolver@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/oxc-resolver/-/oxc-resolver-1.10.2.tgz#d1d2985d458ccec8d42928612a4ac6af3dac4299"
+  integrity sha512-NIbwVqoU8Bhl7PVtItHCg+VFFokIDwBgIgFUwFG2Y8ePhxftFh5xG+KLar5PLWXlCP4WunPIuXD3jr3v6/MfRw==
   optionalDependencies:
-    "@oxc-resolver/binding-darwin-arm64" "1.10.0"
-    "@oxc-resolver/binding-darwin-x64" "1.10.0"
-    "@oxc-resolver/binding-linux-arm-gnueabihf" "1.10.0"
-    "@oxc-resolver/binding-linux-arm64-gnu" "1.10.0"
-    "@oxc-resolver/binding-linux-arm64-musl" "1.10.0"
-    "@oxc-resolver/binding-linux-x64-gnu" "1.10.0"
-    "@oxc-resolver/binding-linux-x64-musl" "1.10.0"
-    "@oxc-resolver/binding-wasm32-wasi" "1.10.0"
-    "@oxc-resolver/binding-win32-arm64-msvc" "1.10.0"
-    "@oxc-resolver/binding-win32-x64-msvc" "1.10.0"
+    "@oxc-resolver/binding-darwin-arm64" "1.10.2"
+    "@oxc-resolver/binding-darwin-x64" "1.10.2"
+    "@oxc-resolver/binding-freebsd-x64" "1.10.2"
+    "@oxc-resolver/binding-linux-arm-gnueabihf" "1.10.2"
+    "@oxc-resolver/binding-linux-arm64-gnu" "1.10.2"
+    "@oxc-resolver/binding-linux-arm64-musl" "1.10.2"
+    "@oxc-resolver/binding-linux-x64-gnu" "1.10.2"
+    "@oxc-resolver/binding-linux-x64-musl" "1.10.2"
+    "@oxc-resolver/binding-wasm32-wasi" "1.10.2"
+    "@oxc-resolver/binding-win32-arm64-msvc" "1.10.2"
+    "@oxc-resolver/binding-win32-x64-msvc" "1.10.2"
 
 p-filter@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- Add `$infer` and `$inferInner` for simpler type extraction
- Add `value` method for getting the unbranded type easily
- Add `matchEnum` for pattern matching enum type (with exhaustive checking and type safety)
- Add `eq` 'static' method in enum types for simpler equality checks